### PR TITLE
Use `close(notify)` as opposed to `notify<-struct{}{}` to signal completion

### DIFF
--- a/client/analytics.go
+++ b/client/analytics.go
@@ -19,9 +19,9 @@ import (
 func (client *client) activateAnalytics() func() {
 
 	// Create a shutdown function.
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{})
 	shutdown := func() {
-		notify <- struct{}{}
+		close(notify)
 	}
 
 	go func() {

--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -21,9 +21,9 @@ import (
 func (client *client) activateBroadcast() func() {
 
 	// Create a shutdown function.
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{})
 	shutdown := func() {
-		notify <- struct{}{}
+		close(notify)
 	}
 
 	// Broadcast artifacts from the send queue.

--- a/client/connect.go
+++ b/client/connect.go
@@ -21,9 +21,9 @@ import (
 func (client *client) discoverStreams() func() {
 
 	// Create a shutdown function.
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{})
 	shutdown := func() {
-		notify <- struct{}{}
+		close(notify)
 	}
 
 	// Replenish the stream store.

--- a/client/discover.go
+++ b/client/discover.go
@@ -20,9 +20,9 @@ import (
 func (client *client) discoverPeers() func() {
 
 	// Create a shutdown function.
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{})
 	shutdown := func() {
-		notify <- struct{}{}
+		close(notify)
 	}
 
 	// Replenish the routing table.

--- a/client/nat_monitor.go
+++ b/client/nat_monitor.go
@@ -20,9 +20,9 @@ import (
 func (client *client) newNATMonitor(listener multiaddr.Multiaddr, manager basichost.NATManager) func() {
 
 	// Create a shutdown function.
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{})
 	shutdown := func() {
-		notify <- struct{}{}
+		close(notify)
 	}
 
 	go func(listener multiaddr.Multiaddr, manager basichost.NATManager) {

--- a/client/process_test.go
+++ b/client/process_test.go
@@ -98,11 +98,11 @@ func TestDuplication(test *testing.T) {
 	}
 
 	// Create notifications to shutdown the artifact forwarding loops.
-	notify2 := make(chan struct{}, 1)
-	notify4 := make(chan struct{}, 1)
+	notify2 := make(chan struct{})
+	notify4 := make(chan struct{})
 	defer func() {
-		notify2 <- struct{}{}
-		notify4 <- struct{}{}
+		close(notify2)
+		close(notify4)
 	}()
 
 	// Forward artifacts from the first client to the third client.

--- a/examples/chirp/main.go
+++ b/examples/chirp/main.go
@@ -257,7 +257,7 @@ func ws(client p2p.Client, counter int, lock *sync.Mutex, logger *logging.Logger
 		}
 
 		counter++
-		notify := make(chan struct{}, 1)
+		notify := make(chan struct{})
 
 		go func() {
 
@@ -278,7 +278,7 @@ func ws(client p2p.Client, counter int, lock *sync.Mutex, logger *logging.Logger
 				client.Send() <- data
 			}
 
-			notify <- struct{}{}
+			close(notify)
 
 		}()
 

--- a/streamstore/streamstore.go
+++ b/streamstore/streamstore.go
@@ -82,7 +82,7 @@ func (ss *streamstore) Add(peerId peer.ID, stream net.Stream) bool {
 	ctx, exists := ss.data[pid]
 	if exists {
 		ss.Debug("Removing", pid, "from stream store")
-		ctx.notify <- struct{}{}
+		close(ctx.notify)
 		ctx.stream.Close()
 		delete(ss.data, pid)
 	} else if ss.Capacity() <= ss.Size() {
@@ -90,7 +90,7 @@ func (ss *streamstore) Add(peerId peer.ID, stream net.Stream) bool {
 		return false
 	}
 	ctx = peerctx{
-		make(chan struct{}, 1),
+		make(chan struct{}),
 		make(chan transaction, ss.txQueueSize),
 		stream,
 	}
@@ -175,7 +175,7 @@ func (ss *streamstore) Purge() {
 	for peerId, ctx := range ss.data {
 		pid := peerId
 		ss.Debug("Removing", pid, "from stream store")
-		ctx.notify <- struct{}{}
+		close(ctx.notify)
 		ctx.stream.Close()
 		delete(ss.data, pid)
 	}
@@ -189,7 +189,7 @@ func (ss *streamstore) Remove(peerId peer.ID) {
 	ctx, exists := ss.data[pid]
 	if exists {
 		ss.Debug("Removing", pid, "from stream store")
-		ctx.notify <- struct{}{}
+		close(ctx.notify)
 		ctx.stream.Close()
 		delete(ss.data, pid)
 	}


### PR DESCRIPTION
It's more idiomatic to close a channel to signal completion.  Also saves us from having to create buffered channels.