### PR TITLE
Remove unnecessary abstraction around stream handlers

### DIFF
--- a/client/pair.go
+++ b/client/pair.go
@@ -79,101 +79,97 @@ func (client *client) pair(peerId peer.ID) (bool, error) {
 }
 
 // Handle incomming pairing requests.
-func (client *client) pairHandler() net.StreamHandler {
+func (client *client) pairHandler(stream net.Stream) {
 
-	return func(stream net.Stream) {
+	// Log this action.
+	pid := stream.Conn().RemotePeer()
+	client.logger.Debug("Receiving request to pair with", pid)
 
-		// Log this action.
-		pid := stream.Conn().RemotePeer()
-		client.logger.Debug("Receiving request to pair with", pid)
+	// Prepare to reject the request.
+	reject := func(reason ...interface{}) {
+		client.logger.Debug("Cannot pair with", pid, "because", fmt.Sprint(reason...))
+		err := util.WriteWithTimeout(
+			stream,
+			[]byte{nak},
+			client.config.Timeout,
+		)
+		if err != nil {
+			client.logger.Warning("Cannot send data to", pid, err)
+		}
+		stream.Close()
+	}
 
-		// Prepare to reject the request.
-		reject := func(reason ...interface{}) {
-			client.logger.Debug("Cannot pair with", pid, "because", fmt.Sprint(reason...))
+	// Check if the peer is closer than others in its bucket.
+	buckets := client.table.Buckets
+	targets := deal(client.streamstore.Capacity(), len(buckets))
+	for i := range buckets {
+
+		if buckets[i].Has(pid) {
+
+			// Select peers from this bucket.
+			peers := client.streamstore.Peers()
+			for j := 0; j < len(peers); j++ {
+				if !buckets[i].Has(peers[j]) {
+					copy(peers[j:], peers[j+1:])
+					peers = peers[:len(peers)-1]
+					j--
+				}
+			}
+
+			if len(peers)+1 > targets[i] {
+
+				// Sort the peers and select the overflow.
+				overflow := kbucket.SortClosestPeers(
+					append(peers, pid),
+					kbucket.ConvertPeerID(client.id),
+				)[targets[i]:]
+
+				// Check if the peer exists in the overflow.
+				for k := range overflow {
+					if overflow[k] == pid {
+						reject("closer peers exist in its bucket")
+						return
+					}
+				}
+
+				// Create space for the stream.
+				client.streamstore.Remove(overflow[len(overflow)-1])
+
+			}
+
+			// Add the stream to the stream store.
+			if !client.streamstore.Add(pid, stream) {
+				reject(pid, " cannot be added to the stream store")
+				return
+			}
+
+			// Send an acknowledgement.
 			err := util.WriteWithTimeout(
 				stream,
-				[]byte{nak},
+				[]byte{ack},
 				client.config.Timeout,
 			)
 			if err != nil {
 				client.logger.Warning("Cannot send data to", pid, err)
-			}
-			stream.Close()
-		}
-
-		// Check if the peer is closer than others in its bucket.
-		buckets := client.table.Buckets
-		targets := deal(client.streamstore.Capacity(), len(buckets))
-		for i := range buckets {
-
-			if buckets[i].Has(pid) {
-
-				// Select peers from this bucket.
-				peers := client.streamstore.Peers()
-				for j := 0; j < len(peers); j++ {
-					if !buckets[i].Has(peers[j]) {
-						copy(peers[j:], peers[j+1:])
-						peers = peers[:len(peers)-1]
-						j--
-					}
-				}
-
-				if len(peers)+1 > targets[i] {
-
-					// Sort the peers and select the overflow.
-					overflow := kbucket.SortClosestPeers(
-						append(peers, pid),
-						kbucket.ConvertPeerID(client.id),
-					)[targets[i]:]
-
-					// Check if the peer exists in the overflow.
-					for k := range overflow {
-						if overflow[k] == pid {
-							reject("closer peers exist in its bucket")
-							return
-						}
-					}
-
-					// Create space for the stream.
-					client.streamstore.Remove(overflow[len(overflow)-1])
-
-				}
-
-				// Add the stream to the stream store.
-				if !client.streamstore.Add(pid, stream) {
-					reject(pid, " cannot be added to the stream store")
-					return
-				}
-
-				// Send an acknowledgement.
-				err := util.WriteWithTimeout(
-					stream,
-					[]byte{ack},
-					client.config.Timeout,
-				)
-				if err != nil {
-					client.logger.Warning("Cannot send data to", pid, err)
-					client.streamstore.Remove(pid)
-					return
-				}
-
-				// Ready to exchange artifacts.
-				client.logger.Debug("Ready to exchange artifacts with", pid)
-				go client.process(stream)
+				client.streamstore.Remove(pid)
 				return
-
 			}
 
-		}
+			// Ready to exchange artifacts.
+			client.logger.Debug("Ready to exchange artifacts with", pid)
+			go client.process(stream)
+			return
 
-		reject(pid, " does not exist in any bucket")
+		}
 
 	}
+
+	reject(pid, " does not exist in any bucket")
 
 }
 
 // Register the pairing handler.
 func (client *client) registerPairService() {
 	uri := client.protocol + "/pair"
-	client.host.SetStreamHandler(uri, client.pairHandler())
+	client.host.SetStreamHandler(uri, client.pairHandler)
 }

--- a/client/sample.go
+++ b/client/sample.go
@@ -83,63 +83,59 @@ func (client *client) sample(peerId peer.ID) ([]peerstore.PeerInfo, error) {
 }
 
 // Handle incomming requests for peers.
-func (client *client) sampleHandler() net.StreamHandler {
+func (client *client) sampleHandler(stream net.Stream) {
 
-	return func(stream net.Stream) {
+	defer stream.Close()
 
-		defer stream.Close()
+	// Log this action.
+	pid := stream.Conn().RemotePeer()
+	client.logger.Debug("Receiving request for peers from", pid)
 
-		// Log this action.
-		pid := stream.Conn().RemotePeer()
-		client.logger.Debug("Receiving request for peers from", pid)
-
-		// Select peers from the routing table.
-		peers := kbucket.SortClosestPeers(
-			client.table.ListPeers(),
-			kbucket.ConvertPeerID(pid),
-		)
-		var sample []peerstore.PeerInfo
-		for len(peers) > 0 {
-			if client.config.SampleSize <= len(sample) {
-				break
-			}
-			n := float64(len(peers))
-			j := int(math.Floor(math.Exp(math.Log(n+1)*rand.Float64()) - 1))
-			info := client.peerstore.PeerInfo(peers[j])
-			if info.ID != client.id && info.ID != pid && len(info.Addrs) != 0 {
-				sample = append(sample, info)
-			}
-			peers = append(peers[:j], peers[j+1:]...)
+	// Select peers from the routing table.
+	peers := kbucket.SortClosestPeers(
+		client.table.ListPeers(),
+		kbucket.ConvertPeerID(pid),
+	)
+	var sample []peerstore.PeerInfo
+	for len(peers) > 0 {
+		if client.config.SampleSize <= len(sample) {
+			break
 		}
-
-		// Encode the peer list.
-		data, err := json.Marshal(sample)
-		if err != nil {
-			client.logger.Warning("Cannot encode peers")
-			return
+		n := float64(len(peers))
+		j := int(math.Floor(math.Exp(math.Log(n+1)*rand.Float64()) - 1))
+		info := client.peerstore.PeerInfo(peers[j])
+		if info.ID != client.id && info.ID != pid && len(info.Addrs) != 0 {
+			sample = append(sample, info)
 		}
-
-		// Send the peer list to the target peer.
-		client.logger.Debug("Providing", pid, "with peers", sample)
-		size := util.EncodeBigEndianUInt32(uint32(len(data)))
-		err = util.WriteWithTimeout(
-			stream,
-			append(size[:], data...),
-			client.config.Timeout,
-		)
-		if err != nil {
-			client.logger.Warning("Cannot send peers to", pid, err)
-		}
-
-		// Update the routing table.
-		client.table.Update(pid)
-
+		peers = append(peers[:j], peers[j+1:]...)
 	}
+
+	// Encode the peer list.
+	data, err := json.Marshal(sample)
+	if err != nil {
+		client.logger.Warning("Cannot encode peers")
+		return
+	}
+
+	// Send the peer list to the target peer.
+	client.logger.Debug("Providing", pid, "with peers", sample)
+	size := util.EncodeBigEndianUInt32(uint32(len(data)))
+	err = util.WriteWithTimeout(
+		stream,
+		append(size[:], data...),
+		client.config.Timeout,
+	)
+	if err != nil {
+		client.logger.Warning("Cannot send peers to", pid, err)
+	}
+
+	// Update the routing table.
+	client.table.Update(pid)
 
 }
 
 // Register the sampling handler.
 func (client *client) registerSampleService() {
 	uri := client.protocol + "/sample"
-	client.host.SetStreamHandler(uri, client.sampleHandler())
+	client.host.SetStreamHandler(uri, client.sampleHandler)
 }


### PR DESCRIPTION
The diff is deceivingly large due to the change in indentation level, but the PR really just changes the `*Handler` functions so that instead of returning a handler, the functions are just handlers themselves.